### PR TITLE
Solucionado pagina menu, boton retroceder (/menu/usuario/"idUsuario")

### DIFF
--- a/backend/middleware/getIdUserToken.js
+++ b/backend/middleware/getIdUserToken.js
@@ -1,0 +1,18 @@
+import jwt from "jsonwebtoken";
+
+const obtnerIdUsuarioPorToken = (req, res) => {
+  const { token } = req.body;
+
+  try {
+    const decodedToken = jwt.verify(token, process.env.JWT_SECRET); // Reemplaza 'tu_secreto' con tu clave secreta real
+
+    const userId = decodedToken.id; // El ID del usuario se extrae del token
+
+    // res.status(200).json({ idUsuario: userId });
+    return res.status(200).json( userId );
+  } catch (error) {
+    res.status(401).json({ error: 'Token no válido' });
+  }
+};
+
+export default obtnerIdUsuarioPorToken;

--- a/backend/routes/usuarioRoutes.js
+++ b/backend/routes/usuarioRoutes.js
@@ -1,11 +1,14 @@
 import { Router } from "express";
 import { registrar, autenticar, obtenerUsuarioPorId } from "../controllers/usuarioController.js";
 import checkAuth from "../middleware/authMiddleware.js";
+import getIdUserToken from "../middleware/getIdUserToken.js"
 
 const router = Router();
 
 router.post("/register", registrar);
 router.post("/login", autenticar);
 router.get("/obtenerUsuarioPorId/:idUsuario", checkAuth, obtenerUsuarioPorId);
+
+router.post('/obtenerIdUsuarioToken', checkAuth, getIdUserToken)
 
 export default router;

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -15,7 +15,7 @@ import { VisualizarPacientesComponent } from './components/visualizar-pacientes/
 const routes: Routes = [
   {path: "", redirectTo: "login", pathMatch: "full"},
   {path: "login", component: LoginComponent},
-  {path: "menu", component: MenuComponent, canActivate: [AuthGuard]},
+  // {path: "menu", component: MenuComponent, canActivate: [AuthGuard]},
   {path: "menu/usuario/:idUsuario", component: MenuComponent, canActivate: [AuthGuard]},
   {path: "menu/usuario/:idUsuario/paciente/:idPaciente", component: MenuComponent, canActivate: [AuthGuard]},
   {path: "visualizar-pacientes/usuario/:idUsuario", component: VisualizarPacientesComponent, canActivate: [AuthGuard]},

--- a/frontend/src/app/components/login/login.component.ts
+++ b/frontend/src/app/components/login/login.component.ts
@@ -20,7 +20,22 @@ export class LoginComponent implements OnInit {
     //   });
     // }
     if (this._authService.loggedin()) {
-      this.router.navigate(['/menu']); // Redirige a la página principal si ya hay una sesión iniciada
+      //this.router.navigate(['/menu']); // Redirige a la página principal si ya hay una sesión iniciada
+      const token = sessionStorage.getItem('token')
+
+      if (token) {
+        this._authService.obtenerIdUsuarioDesdeToken(token).subscribe(
+          (response) => {
+            console.log(response);
+            // const idUsuario = response.idUsuario;
+            // console.log('ID del usuario:', idUsuario);
+            this.router.navigate(['/menu/usuario', response])
+          },
+          (err) => {
+            console.log(err);
+          }
+        )
+      }
     }
   }
 

--- a/frontend/src/app/services/auth.service.ts
+++ b/frontend/src/app/services/auth.service.ts
@@ -33,4 +33,9 @@ export class AuthService {
   obtenerUsuarioPorId(idUsuario: string) {
     return this.httpClient.get<any>(this.url + '/obtenerUsuarioPorId/' + idUsuario);
   }
+
+  obtenerIdUsuarioDesdeToken(token: string) {
+    // Realiza una solicitud al servidor para obtener el ID del usuario basado en el token
+    return this.httpClient.post(`${this.url}/obtenerIdUsuarioToken`, { token });
+  }
 }


### PR DESCRIPTION
Hubo un error en la pagina de menu, cuando un usuario esta autenticado y daba click en el boton retroceder del navegador, este redirigia al url (/menu), cuando deberia redirigir al url (/menu/usuario/"idUsuario"), incluso si se modifica el url que no exista debe redirigir a (/menu/usuario/"idUsuario").

Esto ya esta solucionado y funciona correctamente.

Se realizo creando un codigo en el backend para que traiga solo el idUsuario, lo puse como middleware con el nombre de "getIdUserToken", luego en el frontend lo integre con el servicio "authService" y lo utilice en el componente "login", especificamente en el "ngOnInit", para que cuando haya una sesion iniciada, este almacena el token en el sessionStorage y luego es extraido para mandarlo al servicio y este lo envia al controlador del backend para que me brinde solo el idUsuario a base del token