### PR TITLE
Correccion al mostrar datos del paciente en los formularios

### DIFF
--- a/backend/controllers/pacienteController.js
+++ b/backend/controllers/pacienteController.js
@@ -505,7 +505,7 @@ const obtenerPacienteForm1PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await PacienteModel.findOne({_id:idPaciente});
+        const paciente = await PacienteModel.findOne({paciente:idPaciente});
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });
@@ -525,7 +525,8 @@ const obtenerPacienteForm2PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await Formulario2Model.findOne({_id:idPaciente});
+        const paciente = await Formulario2Model.findOne({paciente:idPaciente});
+        console.log(paciente)
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });
@@ -545,7 +546,7 @@ const obtenerPacienteForm3PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await Formulario3Model.findOne({_id:idPaciente});
+        const paciente = await Formulario3Model.findOne({paciente:idPaciente});
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });
@@ -565,7 +566,7 @@ const obtenerPacienteForm4PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await Formulario4Model.findOne({_id:idPaciente});
+        const paciente = await Formulario4Model.findOne({paciente:idPaciente});
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });
@@ -585,7 +586,7 @@ const obtenerPacienteForm5PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await Formulario5Model.findOne({_id:idPaciente});
+        const paciente = await Formulario5Model.findOne({paciente:idPaciente});
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });
@@ -605,7 +606,7 @@ const obtenerPacienteForm6PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await Formulario6Model.findOne({_id:idPaciente});
+        const paciente = await Formulario6Model.findOne({paciente:idPaciente});
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });
@@ -625,7 +626,7 @@ const obtenerPacienteForm7PorIdPaciente = async (req, res) => {
 
     try {
         // Busca al paciente utilizando el pacienteId
-        const paciente = await Formulario7Model.findOne({_id:idPaciente});
+        const paciente = await Formulario7Model.findOne({paciente:idPaciente});
 
         if (!paciente) {
             return res.status(404).json({ msg: "Paciente no encontrado" });

--- a/frontend/src/app/components/formulario2/formulario2.component.ts
+++ b/frontend/src/app/components/formulario2/formulario2.component.ts
@@ -28,6 +28,9 @@ export class Formulario2Component implements OnInit {
   idUsuario!: any;
   idPaciente!: any;
 
+  public isAdmin: boolean = false;
+  public isUser: boolean = false;
+
   esModoEdicion: boolean = false;
 
   constructor(private _pacienteService: PacienteService, private _authService: AuthService, private router: Router, private aRoute: ActivatedRoute, private toastr: ToastrService){}
@@ -35,8 +38,35 @@ export class Formulario2Component implements OnInit {
   ngOnInit(): void {
     this.idUsuario = this.aRoute.snapshot.paramMap.get('idUsuario');
     this.idPaciente = this.aRoute.snapshot.paramMap.get('idPaciente');
-    this.mostrarDatosPacienteSA()
-    this.mostrarDatos();
+    
+    /** ! Este codigo es momentaneo, ya que posteriormente bloqueare los botones del menu de navegacion
+     * para que no puedan actualizar o volver a registrar paciente que ya existan en la base de datos,
+     * esto en lo que se refiere al usuario normal */
+    if (this.idUsuario !== null) {
+
+      const token = sessionStorage.getItem('token')
+      if (token) {
+        this._authService.obtenerRolUsuarioDesdeToken(token).subscribe(
+          (res) => {
+            console.log(res);
+            this.isAdmin = res === 'administrador';
+            // * Si el token le pertenece al administrador, entonces en la tabla mostrara todos los datos de los pacientes
+            // * registrados en cada formulario sin restriccion de id de usuario
+            if (res === 'administrador') {
+              this.mostrarDatosPacienteSA()
+            } else {
+              this.mostrarDatos();
+            }
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+      }
+    }
+
+    // this.mostrarDatosPacienteSA()
+    // this.mostrarDatos();
   }
 
   // Funcion para autocompletar los campos segun el id del paciente en la url

--- a/frontend/src/app/components/formulario3/formulario3.component.ts
+++ b/frontend/src/app/components/formulario3/formulario3.component.ts
@@ -17,6 +17,9 @@ export class Formulario3Component implements OnInit {
   idUsuario!: any;
   idPaciente!: any;
 
+  public isAdmin: boolean = false;
+  public isUser: boolean = false;
+
   // model!: Formulario3;
 
   esModoEdicion: boolean = false;
@@ -26,8 +29,35 @@ export class Formulario3Component implements OnInit {
   ngOnInit(): void {
     this.idUsuario = this.aRoute.snapshot.paramMap.get('idUsuario');
     this.idPaciente = this.aRoute.snapshot.paramMap.get('idPaciente');
-    this.mostrarDatosPacienteSA();
-    this.mostrarDatos();
+    
+    /** ! Este codigo es momentaneo, ya que posteriormente bloqueare los botones del menu de navegacion
+     * para que no puedan actualizar o volver a registrar paciente que ya existan en la base de datos,
+     * esto en lo que se refiere al usuario normal */
+    if (this.idUsuario !== null) {
+
+      const token = sessionStorage.getItem('token')
+      if (token) {
+        this._authService.obtenerRolUsuarioDesdeToken(token).subscribe(
+          (res) => {
+            console.log(res);
+            this.isAdmin = res === 'administrador';
+            // * Si el token le pertenece al administrador, entonces en la tabla mostrara todos los datos de los pacientes
+            // * registrados en cada formulario sin restriccion de id de usuario
+            if (res === 'administrador') {
+              this.mostrarDatosPacienteSA()
+            } else {
+              this.mostrarDatos();
+            }
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+      }
+    }
+    
+    // this.mostrarDatosPacienteSA();
+    // this.mostrarDatos();
   }
 
   // Funcion para autocompletar los campos segun el id del paciente en la url

--- a/frontend/src/app/components/formulario4/formulario4.component.ts
+++ b/frontend/src/app/components/formulario4/formulario4.component.ts
@@ -17,6 +17,9 @@ export class Formulario4Component implements OnInit {
   idUsuario!: any;
   idPaciente!: any;
 
+  public isAdmin: boolean = false;
+  public isUser: boolean = false;
+
   esModoEdicion: boolean = false;
 
   constructor(private _pacienteService: PacienteService, private _authService: AuthService, private router: Router, private aRoute: ActivatedRoute, private toastr: ToastrService){};
@@ -24,8 +27,35 @@ export class Formulario4Component implements OnInit {
   ngOnInit(): void {
     this.idUsuario = this.aRoute.snapshot.paramMap.get('idUsuario');
     this.idPaciente = this.aRoute.snapshot.paramMap.get('idPaciente');
-    this.mostrarDatosPacienteSA()
-    this.mostrarDatos();
+    
+    /** ! Este codigo es momentaneo, ya que posteriormente bloqueare los botones del menu de navegacion
+     * para que no puedan actualizar o volver a registrar paciente que ya existan en la base de datos,
+     * esto en lo que se refiere al usuario normal */
+    if (this.idUsuario !== null) {
+
+      const token = sessionStorage.getItem('token')
+      if (token) {
+        this._authService.obtenerRolUsuarioDesdeToken(token).subscribe(
+          (res) => {
+            console.log(res);
+            this.isAdmin = res === 'administrador';
+            // * Si el token le pertenece al administrador, entonces en la tabla mostrara todos los datos de los pacientes
+            // * registrados en cada formulario sin restriccion de id de usuario
+            if (res === 'administrador') {
+              this.mostrarDatosPacienteSA()
+            } else {
+              this.mostrarDatos();
+            }
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+      }
+    }
+
+    // this.mostrarDatosPacienteSA()
+    // this.mostrarDatos();
   }
 
   // Funcion para autocompletar los campos segun el id del paciente en la url

--- a/frontend/src/app/components/formulario5/formulario5.component.ts
+++ b/frontend/src/app/components/formulario5/formulario5.component.ts
@@ -32,6 +32,9 @@ export class Formulario5Component implements OnInit {
   idUsuario!: any;
   idPaciente!: any;
 
+  public isAdmin: boolean = false;
+  public isUser: boolean = false;
+
   esModoEdicion: boolean = false;
 
   constructor(private _pacienteService: PacienteService, private _authService: AuthService, private router: Router, private aRoute: ActivatedRoute, private toastr: ToastrService){}
@@ -39,8 +42,35 @@ export class Formulario5Component implements OnInit {
   ngOnInit(): void {
     this.idUsuario = this.aRoute.snapshot.paramMap.get('idUsuario');
     this.idPaciente = this.aRoute.snapshot.paramMap.get('idPaciente');
-    this.mostrarDatosPacienteSA()
-    this.mostrarDatos();
+    
+    /** ! Este codigo es momentaneo, ya que posteriormente bloqueare los botones del menu de navegacion
+     * para que no puedan actualizar o volver a registrar paciente que ya existan en la base de datos,
+     * esto en lo que se refiere al usuario normal */
+    if (this.idUsuario !== null) {
+
+      const token = sessionStorage.getItem('token')
+      if (token) {
+        this._authService.obtenerRolUsuarioDesdeToken(token).subscribe(
+          (res) => {
+            console.log(res);
+            this.isAdmin = res === 'administrador';
+            // * Si el token le pertenece al administrador, entonces en la tabla mostrara todos los datos de los pacientes
+            // * registrados en cada formulario sin restriccion de id de usuario
+            if (res === 'administrador') {
+              this.mostrarDatosPacienteSA()
+            } else {
+              this.mostrarDatos();
+            }
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+      }
+    }
+
+    // this.mostrarDatosPacienteSA()
+    // this.mostrarDatos();
   }
 
   // Funcion para autocompletar los campos segun el id del paciente en la url

--- a/frontend/src/app/components/formulario6/formulario6.component.ts
+++ b/frontend/src/app/components/formulario6/formulario6.component.ts
@@ -37,6 +37,9 @@ export class Formulario6Component implements OnInit {
   idUsuario!: any;
   idPaciente!: any;
 
+  public isAdmin: boolean = false;
+  public isUser: boolean = false;
+
   esModoEdicion: boolean = false;
 
   constructor(private _pacienteService: PacienteService, private _authService: AuthService, private router: Router, private aRoute: ActivatedRoute, private toastr: ToastrService){
@@ -65,8 +68,35 @@ export class Formulario6Component implements OnInit {
   ngOnInit(): void {
     this.idUsuario = this.aRoute.snapshot.paramMap.get('idUsuario');
     this.idPaciente = this.aRoute.snapshot.paramMap.get('idPaciente');
-    this.mostrarDatosPacienteSA()
-    this.mostrarDatos();
+    
+    /** ! Este codigo es momentaneo, ya que posteriormente bloqueare los botones del menu de navegacion
+     * para que no puedan actualizar o volver a registrar paciente que ya existan en la base de datos,
+     * esto en lo que se refiere al usuario normal */
+    if (this.idUsuario !== null) {
+
+      const token = sessionStorage.getItem('token')
+      if (token) {
+        this._authService.obtenerRolUsuarioDesdeToken(token).subscribe(
+          (res) => {
+            console.log(res);
+            this.isAdmin = res === 'administrador';
+            // * Si el token le pertenece al administrador, entonces en la tabla mostrara todos los datos de los pacientes
+            // * registrados en cada formulario sin restriccion de id de usuario
+            if (res === 'administrador') {
+              this.mostrarDatosPacienteSA()
+            } else {
+              this.mostrarDatos();
+            }
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+      }
+    }
+
+    // this.mostrarDatosPacienteSA()
+    // this.mostrarDatos();
   }
 
   // Funcion para autocompletar los campos segun el id del paciente en la url

--- a/frontend/src/app/components/formulario7/formulario7.component.ts
+++ b/frontend/src/app/components/formulario7/formulario7.component.ts
@@ -32,6 +32,9 @@ export class Formulario7Component {
   idUsuario!: any;
   idPaciente!: any;
 
+  public isAdmin: boolean = false;
+  public isUser: boolean = false;
+
   esModoEdicion: boolean = false;
   
   mostrarEvaluacion: boolean = false;
@@ -41,8 +44,35 @@ export class Formulario7Component {
   ngOnInit(): void {
     this.idUsuario = this.aRoute.snapshot.paramMap.get('idUsuario');
     this.idPaciente = this.aRoute.snapshot.paramMap.get('idPaciente');
-    this.mostrarDatosPacienteSA()
-    this.mostrarDatos();
+    
+    /** ! Este codigo es momentaneo, ya que posteriormente bloqueare los botones del menu de navegacion
+     * para que no puedan actualizar o volver a registrar paciente que ya existan en la base de datos,
+     * esto en lo que se refiere al usuario normal */
+    if (this.idUsuario !== null) {
+
+      const token = sessionStorage.getItem('token')
+      if (token) {
+        this._authService.obtenerRolUsuarioDesdeToken(token).subscribe(
+          (res) => {
+            console.log(res);
+            this.isAdmin = res === 'administrador';
+            // * Si el token le pertenece al administrador, entonces en la tabla mostrara todos los datos de los pacientes
+            // * registrados en cada formulario sin restriccion de id de usuario
+            if (res === 'administrador') {
+              this.mostrarDatosPacienteSA()
+            } else {
+              this.mostrarDatos();
+            }
+          },
+          (error) => {
+            console.log(error);
+          }
+        );
+      }
+    }
+
+    // this.mostrarDatosPacienteSA()
+    // this.mostrarDatos();
   }
 
   toggleEvaluacion() {


### PR DESCRIPTION
Se corrigio no al 100% al momento de realizar una busqueda por numero_hc en la pagina menu de navegacion, lo que se hizo momentaneamente es al realizar una busqueda del paciente a traves de su numero_hc e ingresar a algun formulario, mostrar los datos del paciente segun sea el usuario que esta autenticado en ese momento (usuario normal, superadmin).

NOTA: Falta colocar alertas en el boton de buscar por numero_hc en el menu de navegacion, tambien desbloquear solo los botones que aun no se haya registrado los datos del paciente que se ingreso en el buscador