### PR TITLE
Correccion registrar paciente como SUPERADMIN

### DIFF
--- a/backend/controllers/pacienteController.js
+++ b/backend/controllers/pacienteController.js
@@ -435,6 +435,28 @@ const obtenerPacientePorId = async (req, res) => {
         res.status(500).json({ msg: "Ha ocurrido un error" });
     }
 };
+// Funcion para extraer datos del paciente por medio de "idUsuario" y "idPaciente"
+const obtenerPacientePorIdPaciente = async (req, res) => {
+    const { idPaciente } = req.params;
+
+    try {
+        // Aquí asumiremos que tienes un modelo de Mongoose llamado `Paciente` que representa a los pacientes en tu base de datos
+
+        // Luego, busca al paciente utilizando el usuario y el pacienteId
+        const paciente = await PacienteModel.findOne({ _id: idPaciente});
+
+        if (!paciente) {
+            return res.status(404).json({ msg: "Paciente no encontrado" });
+        }
+
+        // Si el paciente existe y está vinculado al usuario, lo devolvemos
+        res.status(200).json({ paciente });
+
+    } catch (error) {
+        console.error(error);
+        res.status(500).json({ msg: "Ha ocurrido un error" });
+    }
+};
 
 // * Obtencion de los datos de todos los pacientes registrados por todos los Usuarios
 // Funcion para obtener pacientes del formulario 1
@@ -800,6 +822,7 @@ export {
     obtenerIds,
     obtenerIdsForm,
     obtenerPacientePorId,
+    obtenerPacientePorIdPaciente,
     obtenerPacienteForm1PorIdPaciente,
     obtenerPacienteForm2PorIdPaciente,
     obtenerPacienteForm3PorIdPaciente,

--- a/backend/routes/pacienteRoutes.js
+++ b/backend/routes/pacienteRoutes.js
@@ -4,6 +4,7 @@ import {
     obtenerIds,
     obtenerIdsForm,
     obtenerPacientePorId,
+    obtenerPacientePorIdPaciente,
     registrarPacienteForm1,
     registrarPacienteForm2,
     registrarPacienteForm3,
@@ -74,6 +75,7 @@ router.get("/obtenerIds", checkAuth, obtenerIds);
 router.get("/obtenerIdsForm", checkAuth, obtenerIdsForm);
 router.get("/obtenerPacientePorId", checkAuth, obtenerPacientePorId);
 router.get("/obtenerPacientePorId/:idUsuario/:idPaciente", checkAuth, obtenerPacientePorId)
+router.get("/obtenerPacientePorIdPaciente/:idPaciente", checkAuth, obtenerPacientePorIdPaciente)
 
 router.get("/obtenerPacienteForm1PorIdPaciente/:idPaciente", checkAuth, obtenerPacienteForm1PorIdPaciente)
 router.get("/obtenerPacienteForm2PorIdPaciente/:idPaciente", checkAuth, obtenerPacienteForm2PorIdPaciente)

--- a/frontend/src/app/components/formulario1/formulario1.component.ts
+++ b/frontend/src/app/components/formulario1/formulario1.component.ts
@@ -93,6 +93,26 @@ export class Formulario1Component implements OnInit {
     }
   }
 
+  // //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  // obtenerDatosPaciente(){
+  //   this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+  //     (res) => {
+  //       console.log(res);
+  //       this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+  //       this.datos.numero_hc = res.paciente.numero_hc;
+  //       this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+  //       this.datos.nombre = res.paciente.nombre;
+  //       this.datos.fecha = res.paciente.fecha;
+  //       this.datos.firma = res.paciente.firma;
+  //     },
+  //     (error) => {
+  //       console.log(error);
+  //     }
+  //   )
+  // }
+
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -114,6 +134,7 @@ export class Formulario1Component implements OnInit {
     }
   }
 
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -351,7 +372,7 @@ export class Formulario1Component implements OnInit {
           (res) => {
             console.log(res);
             
-            this.toastr.success('Los datos de la paciente fueron registrados con exito!', 'Paciente Registrado!')
+            this.toastr.success('Datos sociodemográficos de la paciente fue registrado con exito!', 'Datos Sociodemográficos de la Paciente Registrado!')
 
             this._pacienteService.obtenerIds(this.datos.numero_hc).subscribe(
               (result) => {

--- a/frontend/src/app/components/formulario2/formulario2.component.ts
+++ b/frontend/src/app/components/formulario2/formulario2.component.ts
@@ -54,6 +54,7 @@ export class Formulario2Component implements OnInit {
             // * registrados en cada formulario sin restriccion de id de usuario
             if (res === 'administrador') {
               this.mostrarDatosPacienteSA()
+              this.obtenerDatosPaciente()
             } else {
               this.mostrarDatos();
             }
@@ -69,6 +70,26 @@ export class Formulario2Component implements OnInit {
     // this.mostrarDatos();
   }
 
+  //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  obtenerDatosPaciente(){
+    this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+      (res) => {
+        console.log(res);
+        this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+        this.datos.numero_hc = res.paciente.numero_hc;
+        this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+        this.datos.nombre = res.paciente.nombre;
+        this.datos.fecha = res.paciente.fecha;
+        this.datos.firma = res.paciente.firma;
+      },
+      (error) => {
+        console.log(error);
+      }
+    )
+  }
+
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -91,6 +112,7 @@ export class Formulario2Component implements OnInit {
     }
   }
 
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -132,6 +154,9 @@ export class Formulario2Component implements OnInit {
       this._pacienteService.editarPacienteForm2(this.idPaciente, this.datos).subscribe(
         (res) => {
           console.log(res);
+          
+          this.toastr.info('Los datos de la paciente fueron actualizados con exito!', 'Paciente Actualizado!')
+          
           this._authService.obtenerUsuarioPorId(this.idUsuario).subscribe(
             (res) => {
               // console.log(res);

--- a/frontend/src/app/components/formulario3/formulario3.component.ts
+++ b/frontend/src/app/components/formulario3/formulario3.component.ts
@@ -45,6 +45,7 @@ export class Formulario3Component implements OnInit {
             // * registrados en cada formulario sin restriccion de id de usuario
             if (res === 'administrador') {
               this.mostrarDatosPacienteSA()
+              this.obtenerDatosPaciente()
             } else {
               this.mostrarDatos();
             }
@@ -60,6 +61,26 @@ export class Formulario3Component implements OnInit {
     // this.mostrarDatos();
   }
 
+  //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  obtenerDatosPaciente(){
+    this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+      (res) => {
+        console.log(res);
+        this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+        this.datos.numero_hc = res.paciente.numero_hc;
+        this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+        this.datos.nombre = res.paciente.nombre;
+        this.datos.fecha = res.paciente.fecha;
+        this.datos.firma = res.paciente.firma;
+      },
+      (error) => {
+        console.log(error);
+      }
+    )
+  }
+
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -82,6 +103,7 @@ export class Formulario3Component implements OnInit {
     }
   }
   
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -116,6 +138,9 @@ export class Formulario3Component implements OnInit {
       this._pacienteService.editarPacienteForm3(this.idPaciente, this.datos).subscribe(
         (res) => {
           console.log(res);
+
+          this.toastr.info('Los datos de la paciente fueron actualizados con exito!', 'Paciente Actualizado!')
+
           this._authService.obtenerUsuarioPorId(this.idUsuario).subscribe(
             (res) => {
               // console.log(res);

--- a/frontend/src/app/components/formulario4/formulario4.component.ts
+++ b/frontend/src/app/components/formulario4/formulario4.component.ts
@@ -43,6 +43,7 @@ export class Formulario4Component implements OnInit {
             // * registrados en cada formulario sin restriccion de id de usuario
             if (res === 'administrador') {
               this.mostrarDatosPacienteSA()
+              this.obtenerDatosPaciente()
             } else {
               this.mostrarDatos();
             }
@@ -58,6 +59,26 @@ export class Formulario4Component implements OnInit {
     // this.mostrarDatos();
   }
 
+  //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  obtenerDatosPaciente(){
+    this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+      (res) => {
+        console.log(res);
+        this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+        this.datos.numero_hc = res.paciente.numero_hc;
+        this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+        this.datos.nombre = res.paciente.nombre;
+        this.datos.fecha = res.paciente.fecha;
+        this.datos.firma = res.paciente.firma;
+      },
+      (error) => {
+        console.log(error);
+      }
+    )
+  }
+
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -80,6 +101,7 @@ export class Formulario4Component implements OnInit {
     }
   }
 
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -128,6 +150,9 @@ export class Formulario4Component implements OnInit {
       this._pacienteService.editarPacienteForm4(this.idPaciente, this.datos).subscribe(
         (res) => {
           console.log(res);
+
+          this.toastr.info('Los datos de la paciente fueron actualizados con exito!', 'Paciente Actualizado!')
+
           this._authService.obtenerUsuarioPorId(this.idUsuario).subscribe(
             (res) => {
               // console.log(res);

--- a/frontend/src/app/components/formulario5/formulario5.component.ts
+++ b/frontend/src/app/components/formulario5/formulario5.component.ts
@@ -58,6 +58,7 @@ export class Formulario5Component implements OnInit {
             // * registrados en cada formulario sin restriccion de id de usuario
             if (res === 'administrador') {
               this.mostrarDatosPacienteSA()
+              this.obtenerDatosPaciente()
             } else {
               this.mostrarDatos();
             }
@@ -73,6 +74,26 @@ export class Formulario5Component implements OnInit {
     // this.mostrarDatos();
   }
 
+  //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  obtenerDatosPaciente(){
+    this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+      (res) => {
+        console.log(res);
+        this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+        this.datos.numero_hc = res.paciente.numero_hc;
+        this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+        this.datos.nombre = res.paciente.nombre;
+        this.datos.fecha = res.paciente.fecha;
+        this.datos.firma = res.paciente.firma;
+      },
+      (error) => {
+        console.log(error);
+      }
+    )
+  }
+
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -95,6 +116,7 @@ export class Formulario5Component implements OnInit {
     }
   }
 
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -150,6 +172,9 @@ export class Formulario5Component implements OnInit {
       this._pacienteService.editarPacienteForm5(this.idPaciente, this.datos).subscribe(
         (res) => {
           console.log(res);
+
+          this.toastr.info('Los datos de la paciente fueron actualizados con exito!', 'Paciente Actualizado!')
+
           this._authService.obtenerUsuarioPorId(this.idUsuario).subscribe(
             (res) => {
               // console.log(res);

--- a/frontend/src/app/components/formulario6/formulario6.component.ts
+++ b/frontend/src/app/components/formulario6/formulario6.component.ts
@@ -84,6 +84,7 @@ export class Formulario6Component implements OnInit {
             // * registrados en cada formulario sin restriccion de id de usuario
             if (res === 'administrador') {
               this.mostrarDatosPacienteSA()
+              this.obtenerDatosPaciente()
             } else {
               this.mostrarDatos();
             }
@@ -99,6 +100,26 @@ export class Formulario6Component implements OnInit {
     // this.mostrarDatos();
   }
 
+  //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  obtenerDatosPaciente(){
+    this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+      (res) => {
+        console.log(res);
+        this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+        this.datos.numero_hc = res.paciente.numero_hc;
+        this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+        this.datos.nombre = res.paciente.nombre;
+        this.datos.fecha = res.paciente.fecha;
+        this.datos.firma = res.paciente.firma;
+      },
+      (error) => {
+        console.log(error);
+      }
+    )
+  }
+
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -121,6 +142,7 @@ export class Formulario6Component implements OnInit {
     }
   }
 
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -171,6 +193,9 @@ export class Formulario6Component implements OnInit {
       this._pacienteService.editarPacienteForm6(this.idPaciente, this.datos).subscribe(
         (res) => {
           console.log(res);
+
+          this.toastr.info('Los datos de la paciente fueron actualizados con exito!', 'Paciente Actualizado!')
+
           this._authService.obtenerUsuarioPorId(this.idUsuario).subscribe(
             (res) => {
               // console.log(res);

--- a/frontend/src/app/components/formulario7/formulario7.component.ts
+++ b/frontend/src/app/components/formulario7/formulario7.component.ts
@@ -60,6 +60,7 @@ export class Formulario7Component {
             // * registrados en cada formulario sin restriccion de id de usuario
             if (res === 'administrador') {
               this.mostrarDatosPacienteSA()
+              this.obtenerDatosPaciente()
             } else {
               this.mostrarDatos();
             }
@@ -75,6 +76,25 @@ export class Formulario7Component {
     // this.mostrarDatos();
   }
 
+  //** Esta funcion solo trae "iniciales_paciente", "numero_hc", "centro_institucion_atencion", "nombre", "fecha" y "firma" unicamente con el id del paciente para poder registrar (SUPERADMIN) */
+  obtenerDatosPaciente(){
+    this._pacienteService.obtenerPacientePorIdPaciente(this.idPaciente).subscribe(
+      (res) => {
+        console.log(res);
+        this.datos.iniciales_paciente = res.paciente.iniciales_paciente;
+        this.datos.numero_hc = res.paciente.numero_hc;
+        this.datos.centro_institucion_atencion = res.paciente.centro_institucion_atencion;
+        
+        this.datos.nombre = res.paciente.nombre;
+        this.datos.fecha = res.paciente.fecha;
+        this.datos.firma = res.paciente.firma;
+      },
+      (error) => {
+        console.log(error);
+      }
+    )
+  }
+
   toggleEvaluacion() {
     // Si se selecciona Ciclo 3 o Ciclo 6, mostrar el bloque de Evaluación de respuesta al tratamiento
     if (this.datos.ciclo === 'CICLO 03' || this.datos.ciclo === 'CICLO 06') {
@@ -84,6 +104,7 @@ export class Formulario7Component {
     }
   }
 
+  //** Esta funcion es para (USUARIO) */
   // Funcion para autocompletar los campos segun el id del paciente en la url
   mostrarDatos() {
     if (this.idPaciente !== null) {
@@ -106,6 +127,7 @@ export class Formulario7Component {
     }
   }
 
+  //** Esta funcion es para (SUPERADMIN) */
   mostrarDatosPacienteSA() {
     if (this.idPaciente !== null) {
       console.log(this.idPaciente);
@@ -164,6 +186,9 @@ export class Formulario7Component {
       this._pacienteService.editarPacienteForm7(this.idPaciente, this.datos).subscribe(
         (res) => {
           console.log(res);
+
+          this.toastr.info('Los datos de la paciente fueron actualizados con exito!', 'Paciente Actualizado!')
+
           this._authService.obtenerUsuarioPorId(this.idUsuario).subscribe(
             (res) => {
               // console.log(res);

--- a/frontend/src/app/services/paciente.service.ts
+++ b/frontend/src/app/services/paciente.service.ts
@@ -126,6 +126,10 @@ export class PacienteService {
   obtenerPacientePorId(idUsuario:any, idPaciente: any): Observable<any> {
     return this.httpClient.get(`${this.url}/obtenerPacientePorId/${idUsuario}/${idPaciente}`);
   }
+  // Funcion para obetner el "iniciales_paciente, numero_hc, institucion_centro_atencion" del paciente (Usado en el "ngOnInit" de la pagina formulario2.ts)
+  obtenerPacientePorIdPaciente(idPaciente: any): Observable<any> {
+    return this.httpClient.get(`${this.url}/obtenerPacientePorIdPaciente/${idPaciente}`);
+  }
 
   // * Obtener los datos del paciente solo por el idPaciente
   // Funcion para obetner los datos del paciente para el formulario 1 solo con el idPaciente


### PR DESCRIPTION
Se realizo la programacion de solo traer el inicial_paciente, numero_hc, centro_institucion_atencion, nombre, fecha y firma, solo por el id del paciente, esto lo hice para que el SUPERADMIN pueda registrar pacientes.

Tambien se agrego las alertas "toast" cuando el SUPERADMIN quiera editar a un paciente